### PR TITLE
Prevent wrong positioning when ".dokuwiki:first" is relatively positioned

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,4 @@
 
-
 // Queue of loaded script files
 var indexmenu_jsqueue = new Array();
 // Context menu
@@ -67,7 +66,7 @@ function indexmenu_createPicker(id, cl) {
         .attr('id', id)
         .css({position: 'absolute'})
         .hide()
-        .appendTo('.dokuwiki:first');
+        .appendTo('body');
 }
 
 /**


### PR DESCRIPTION
Appending the Picker to ".dokuwiki:first" may cause differences betweem calculated mouseposition and "css absolute positioning" when CSS Style "position:relative" is set to a parent of the picker. See issue #26.
