### PR TITLE
Remove all empty directories from index.

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -16,4 +16,3 @@ $conf['skip_file']     = '';
 $conf['show_sort']     = 1;
 $conf['themes_url']    = 'http://samuele.netsons.org/dokuwiki';
 $conf['be_repo']       = 0;
-$conf['sneaky_index']  = (isset($GLOBALS['conf']['sneaky_index'])) ? $GLOBALS['conf']['sneaky_index'] : 1;

--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -587,7 +587,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
                     return false;
             }
             //check ACL (for sneaky_index namespaces too).
-            if($this->getConf('sneaky_index') && auth_quickaclcheck($id.':') < AUTH_READ) return false;
+            if($conf['sneaky_index'] && auth_quickaclcheck($id.':') < AUTH_READ) return false;
             //Open requested level
             if($opts['level'] > $lvl || $opts['level'] == -1) $isopen = true;
             //Search optional namespaces


### PR DESCRIPTION
This removes empty dirs as much as possible, so fixes #79 and #62 
- sneaky_index helps preventing empty forbidden namespaces
  (especially when nodes are not unfolded/not loaded for some levels), but
  can hide deeper allowed nodes of course.
- this removing of empty dirs is only performed for the sort options:
  tsort, dsort,msort,nsort and hsort.
