### PR TITLE
define default for the options in the Config manager

### DIFF
--- a/_test/indexmenu_syntax_indexmenu.test.php
+++ b/_test/indexmenu_syntax_indexmenu.test.php
@@ -136,7 +136,7 @@ class indexmenu_syntax_indexmenu_test extends DokuWikiTest {
             array(
                 'syntax'=> "{{indexmenu>#1|js#bj_ubuntu.png navbar context nocookie noscroll notoc nomenu dsort msort#date:modified hsort rsort nsort nons nopg max#2#4 maxjs#3 id#54321}}",
                 'data'  => array(
-                    '', 'bj_ubuntu.png', 54321, true, true, true, 3, true, '&max=4&sort=d&msort=date modified&rsort=1&nsort=1&hsort=1&nopg=1', true, true,
+                    '', 'bj_ubuntu.png', 54321, true, true, true, 3, true, '&sort=d&msort=date modified&rsort=1&nsort=1&hsort=1&nopg=1&max=4', true, true,
                     'd', 'date modified', true, true, 1, true, true, array(), 2, true, array(''), array(''), true,
                     ":start:,:same:,:inside:", 1
                 )

--- a/conf/default.php
+++ b/conf/default.php
@@ -5,6 +5,7 @@
  * @license:    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author:     Samuele Tognini <samuele@samuele.netsons.org>
  */
+$conf['defaultoptions'] = '';
 $conf['only_admins']   = 0;
 $conf['aclcache']      = 'groups';
 $conf['headpage']      = ':start:,:same:,:inside:';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,6 +5,7 @@
  * @license:    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author:     Samuele Tognini <samuele@samuele.netsons.org>
  */
+$meta['defaultoptions'] = array('string');
 $meta['only_admins']   = array('onoff','_caution' => 'warning');
 $meta['aclcache']      = array('multichoice', '_choices' => array('none', 'user', 'groups'));
 $meta['headpage']      = array('multicheckbox', '_choices' => array(':start:', ':same:', ':inside:'));


### PR DESCRIPTION
default can be undone by the inverse of the original command:
e.g.:
noscroll, undo by: scroll
tsort, undo by: notsort
etc

Fixes #97
- inverse commands are ignored in the defaults (because this are already
  the defaults)
- skipns and skipfile have already separated config options (skip_index
  and skip_file) in the  Config manager
