### PR TITLE
Remove unicode <200b> Zero Width Spaces from $match in {{indexmenu_n>​40}}

### DIFF
--- a/syntax/tag.php
+++ b/syntax/tag.php
@@ -42,6 +42,7 @@ class syntax_plugin_indexmenu_tag extends DokuWiki_Syntax_Plugin {
      */
     function handle($match, $state, $pos, Doku_Handler $handler) {
         $match = substr($match, 14, -2);
+        $match = str_replace("\xE2\x80\x8B", "", $match);
         return array($match);
     }
 


### PR DESCRIPTION
Occasionally Zero Width Spaces appear between the '>' and the
indexnumber and thus the tag appears to be not working without any apparent
reason. This PR removes those Zero Width Spaces.