### PR TITLE
Add optional support for replacing underscores in node names by spaces.

### DIFF
--- a/_test/indexmenu_syntax_indexmenu.test.php
+++ b/_test/indexmenu_syntax_indexmenu.test.php
@@ -35,7 +35,7 @@ class indexmenu_syntax_indexmenu_test extends DokuWikiTest {
      */
     function createData($values) {
 
-        list($ns, $theme, $identifier, $nocookie, $navbar, $noscroll, $maxjs, $notoc, $jsajax, $context, $nomenu,
+        list($ns, $theme, $identifier, $nocookie, $navbar, $noscroll, $maxjs, $notoc, $scorespace, $jsajax, $context, $nomenu,
             $sort, $msort, $rsort, $nsort, $level, $nons, $nopg, $nss, $max, $js, $skipns, $skipfile, $hsort,
             $headpage, $hide_headpage) = $values;
 
@@ -49,6 +49,7 @@ class indexmenu_syntax_indexmenu_test extends DokuWikiTest {
                 'noscroll'   => $noscroll,
                 'maxjs'      => $maxjs,
                 'notoc'      => $notoc,
+                'scorespace' => $scorespace,
                 'jsajax'     => $jsajax,
                 'context'    => $context,
                 'nomenu'     => $nomenu,
@@ -125,7 +126,7 @@ class indexmenu_syntax_indexmenu_test extends DokuWikiTest {
             ),
             //root ns, #levels=1, all options
             array(
-                'syntax'=> "{{indexmenu>#1|navbar context nocookie noscroll notoc nomenu dsort msort#date:modified hsort rsort nsort nons nopg max#2#4 maxjs#3 id#54321}}",
+                'syntax'=> "{{indexmenu>#1|navbar context nocookie noscroll notoc scorespace nomenu dsort msort#date:modified hsort rsort nsort nons nopg max#2#4 maxjs#3 id#54321}}",
                 'data'  => array(
                     '', 'default', 'random', true, true, true, 0, true, '&sort=d&msort=date modified&rsort=1&nsort=1&hsort=1&nopg=1', true, true,
                     'd', 'date modified', true, true, 1, true, true, array(), 0, false, array(''), array(''), true,
@@ -134,7 +135,7 @@ class indexmenu_syntax_indexmenu_test extends DokuWikiTest {
             ),
             //root ns, #levels=1, js renderer, all options
             array(
-                'syntax'=> "{{indexmenu>#1|js#bj_ubuntu.png navbar context nocookie noscroll notoc nomenu dsort msort#date:modified hsort rsort nsort nons nopg max#2#4 maxjs#3 id#54321}}",
+                'syntax'=> "{{indexmenu>#1|js#bj_ubuntu.png navbar context nocookie noscroll notoc scorespace nomenu dsort msort#date:modified hsort rsort nsort nons nopg max#2#4 maxjs#3 id#54321}}",
                 'data'  => array(
                     '', 'bj_ubuntu.png', 54321, true, true, true, 3, true, '&sort=d&msort=date modified&rsort=1&nsort=1&hsort=1&nopg=1&max=4', true, true,
                     'd', 'date modified', true, true, 1, true, true, array(), 2, true, array(''), array(''), true,

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -46,6 +46,7 @@ $lang['js']['context']         = 'Den Baum auf Basis des aktuellen Namensraums a
 $lang['js']['nocookie']        = 'Den Geöffnet/Geschlossen-Status einzelner Knoten nicht speichern während der Navigation';
 $lang['js']['noscroll']        = 'Das Scrollen des Baums ausschalten, wenn er nicht auf die Seite passt';
 $lang['js']['notoc']           = 'Vorschau des Inhaltsverzeichnisses deaktivieren';
+$lang['js']['scorespace']      = 'Ersetzung der Unterstriche mit Leerzeichen';
 $lang['js']['tsort']           = 'Nach Titel';
 $lang['js']['dsort']           = 'Nach Datum';
 $lang['js']['msort']           = 'Nach Meta-Tag';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -44,6 +44,7 @@ $lang['js']['context']         = 'Display the tree of the current wiki namespace
 $lang['js']['nocookie']        = 'Don\'t remember open/closed nodes during user navigation';
 $lang['js']['noscroll']        = 'Prevent to scrolling the tree when it does not fit its container width';
 $lang['js']['notoc']           = 'Disable the toc preview feature';
+$lang['js']['scorespace']      = 'Replace underscores with space';
 $lang['js']['tsort']           = 'By title';
 $lang['js']['dsort']           = 'By date';
 $lang['js']['msort']           = 'By meta tag';

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -44,6 +44,7 @@ $lang['js']['context']         = 'Affiche l\'arborescence du contexte de la cat�
 $lang['js']['nocookie']        = 'Ne pas se souvenir des noeuds ouverts/fermés pendant la navigation de l\'utilisateur';
 $lang['js']['noscroll']        = 'Empêche de faire défiler l\'arbre quand il ne tient pas dans la largeur de son conteneur';
 $lang['js']['notoc']           = 'Désactive la fonction de prévisualisation de la table des matières';
+$lang['js']['scorespace']      = 'Remplacement de soulignement avec des espaces';
 $lang['js']['tsort']           = 'Par titre';
 $lang['js']['dsort']           = 'Par date';
 $lang['js']['msort']           = 'Par meta-tag';

--- a/scripts/indexmenu.js
+++ b/scripts/indexmenu.js
@@ -74,6 +74,7 @@ function dTree(objName, theme) {
         useCookies: true,                              // use cookies (set in page) e.g. disabled for context option
         scroll: true,                                  // enable scrolling of tree in too small columns (set in page)
         toc: true,                                     // enable ToC popups in tree (set in page)
+        scorespace: false,                             // replace underscores with space
         maxjs: 1,                                      // number set by maxjs option (set in page)
         jsajax: '',                                    //  &max=#&sort=(t|d)&msort=(indexmenu_n|<metakey>)&rsort=1&nsort=1&hsort=1&nopg=1&skipns=+=/.../&skipfile=+=/.../(set in page)
         sepchar: ':',                                  // value ':', ';' or '/'  (set in page)
@@ -266,12 +267,21 @@ dTree.prototype.node = function (node, nodeId) {
         (node.hns) ? str += node.hns : str += node.dokuid;
         str += '"' + ' title="' + node.name + '"' + jsfnc;
         str += ' onclick="javascript: ' + this.obj + '.s(' + nodeId + ');"';
-        str += '>' + node.name + '</a>';
+        if(this.config.scorespace)
+            str += '>' + node.name.replace(/_/g, " ") + '</a>';
+        else
+            str += '>' + node.name + '</a>';
     }
     else if (node.pid != this.root.id) {
-        str += '<a id="s' + this.obj + nodeId + '" href="javascript: ' + this.obj + '.o(' + nodeId + '); " class="node"' + jsfnc + '>' + node.name + '</a>';
+        if(this.config.scorespace)
+            str += '<a id="s' + this.obj + nodeId + '" href="javascript: ' + this.obj + '.o(' + nodeId + '); " class="node"' + jsfnc + '>' + node.name.replace(/_/g, " ") + '</a>';
+        else
+            str += '<a id="s' + this.obj + nodeId + '" href="javascript: ' + this.obj + '.o(' + nodeId + '); " class="node"' + jsfnc + '>' + node.name + '</a>';
     } else {
-        str += node.name;
+        if(this.config.scorespace)
+            str += node.name.replace(/_/g, " ");
+        else
+            str += node.name;
     }
     str += '</div>';
     if (node._hc) {
@@ -895,7 +905,10 @@ dTree.prototype.contextmenu = function (n, e) {
     IndexmenuContextmenu.mouseposition(rmenu, e);
     var cmenu = window.indexmenu_contextmenu;
     node = this.aNodes[n];
-    rmenu.innerHTML = '<div class="indexmenu_rmenuhead" title="' + node.name + '">' + node.name + "</div>";
+    if(this.config.scorespace)
+        rmenu.innerHTML = '<div class="indexmenu_rmenuhead" title="' + node.name + '">' + node.name.replace(/_/g, " ") + "</div>";
+    else
+        rmenu.innerHTML = '<div class="indexmenu_rmenuhead" title="' + node.name + '">' + node.name + "</div>";
     rmenu.appendChild(document.createElement('ul'));
     type = (node.isdir || node._hc) ? 'ns' : 'pg';
     IndexmenuContextmenu.arrconcat(cmenu['all'][type], this, n);

--- a/scripts/toolbarindexwizard.js
+++ b/scripts/toolbarindexwizard.js
@@ -32,7 +32,8 @@ var indexmenu_wiz = {
                 context: {},
                 nocookie: {tlbclass: 'js'},
                 noscroll: {tlbclass: 'js'},
-                notoc: {tlbclass: 'js'}
+                notoc: {tlbclass: 'js'},
+                scorespace: {tlbclass: 'js'}
             }
         },
         div4: {

--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -118,6 +118,8 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
         $nopg = $this->hasOption($defaults, $opts, 'nopg');
         //disable toc preview
         $notoc = $this->hasOption($defaults, $opts, 'notoc');
+        //disable underscore to space
+        $scorespace = $this->hasOption($defaults, $opts, 'scorespace');
         //disable the right context menu
         $nomenu = $this->hasOption($defaults, $opts, 'nomenu');
         //Main sort method
@@ -237,7 +239,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
         }
 
         //js options
-        $js_opts = compact('theme', 'identifier', 'nocookie', 'navbar', 'noscroll', 'maxjs', 'notoc', 'jsajax', 'context', 'nomenu');
+        $js_opts = compact('theme', 'identifier', 'nocookie', 'navbar', 'noscroll', 'maxjs', 'notoc', 'scorespace', 'jsajax', 'context', 'nomenu');
 
         return array(
             $ns,
@@ -387,7 +389,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
     private function _indexmenu($myns) {
         global $conf;
         $ns          = $myns[0];
-        $js_opts     = $myns[1]; //theme, identifier, nocookie, navbar, noscroll, maxjs, notoc, jsajax, context, nomenu
+        $js_opts     = $myns[1]; //theme, identifier, nocookie, navbar, noscroll, maxjs, notoc, scorespace, jsajax, context, nomenu
         $this->sort  = $myns[2];
         $this->msort = $myns[3];
         $this->rsort = $myns[4];
@@ -464,6 +466,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
         $out .= "$js_name.config.urlbase='".substr(wl(":"), 0, -1)."';\n";
         $out .= "$js_name.config.sepchar='".$sepchar."';\n";
         if($js_opts['notoc'])          $out .= "$js_name.config.toc=false;\n";
+        if($js_opts['scorespace'])     $out .= "$js_name.config.scorespace=true;\n";
         if($js_opts['nocookie'])       $out .= "$js_name.config.useCookies=false;\n";
         if($js_opts['noscroll'])       $out .= "$js_name.config.scroll=false;\n";
         if($js_opts['maxjs'] > 0)      $out .= "$js_name.config.maxjs=".$js_opts['maxjs'].";\n";


### PR DESCRIPTION
Hello,

This is a patch that adds an option (```scorespace```) that will make indexmenu replace underscores in node names with spaces. Although Dokuwiki has the [useheading](https://www.dokuwiki.org/config:useheading) option, sometimes none of those options are good enough. With the Dokuwiki ```useheading``` option, you get the choice between having page names with underscores or, in short, using the first heading which is not a viable solution because you may start pages with something else other than a title (ie: "About" or "Introduction", etc...).

One of the problems is that, suppose you have a menu item generated as:

```auction_items_under_existing_character```

and if you stumble onto the page with the index and you know you are looking for something related to ```items``` or ```auction```, then if you search in any browser for strings such as ```auction items```, nothing will be found - even though that exact semantic is present on the page.

With this patch and by setting the option ```scorespace``` to the list of javascript options (next to notoc,  and the rest), indexmenu will replace any underscores in node names with a single space character. It is a solution local to indexmenu to avoid setting the Dokuwiki ```useheading``` option and instead have indexmenu generate items with spaces for you.

Please apply if useful!

Regards,

