### PR TITLE
New features : Custom Titles and Table of Contents Order

### DIFF
--- a/syntax/customtitle.php
+++ b/syntax/customtitle.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Info Indexmenu title: custom title
+ *
+ * @license     GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author      ZhangMing
+ *
+ */
+
+if(!defined('DOKU_INC')) die();
+
+/**
+ * All DokuWiki plugins to extend the parser/rendering mechanism
+ * need to inherit from this class
+ */
+class syntax_plugin_indexmenu_customtitle extends DokuWiki_Syntax_Plugin {
+
+    /**
+     * What kind of syntax are we?
+     */
+    function getType() {
+        return 'substition';
+    }
+
+    /**
+     * Where to sort in?
+     */
+    function getSort() {
+        return 140;
+    }
+
+    /**
+     * Connect pattern to lexer
+     */
+    function connectTo($mode) {
+        $this->Lexer->addSpecialPattern('{{indexmenu_title>.+?}}', $mode, 'plugin_indexmenu_customtitle');
+    }
+
+    /**
+     * Handle the match
+     */
+    function handle($match, $state, $pos, Doku_Handler $handler) {
+        $match = substr($match, 18, -2);
+        return array($match);
+    }
+
+    /**
+     * Render output
+     */
+    function render($mode, Doku_Renderer $renderer, $data) {
+        if($mode == 'metadata') {
+            /** @var Doku_Renderer_metadata $renderer */
+            $renderer->meta['indexmenu_title'] = $data[0];
+        }
+    }
+}


### PR DESCRIPTION
## NEW FEATURES
Added two features :
  - Add `indexmenu_title` tag : You can use this tag to define the name of the index title displayed
  - Both pages and namespaces are sorted by `indexmenu_n` tag

### custom index title
**Syntax :** `{{indexmenu_title>YOUR_TITLE}}` \
title display priority ： `indexmenu_title` > page title > file name

### custom index order
Both namespaces and pages are now sorted according to the value of `indexmenu_n` .\
The `indexmenu_n`  value of the directory is determined by the **homepage** .

```
ns_1
|---- page_1                  ..... indexmenu_n = 1
|---- page_2                  ..... indexmenu_n = 2
|---- ns_2                    ..... indexmenu_n = 3 ( homepage )
|     |---- page_23           ..... indexmenu_n = 1
|     |---- page_24           ..... indexmenu_n = 2
|
|---- page_3                  ..... indexmenu_n = 4
|---- page_4                  ..... indexmenu_n = 5
```
