### PR TITLE
previewing site without toc: makes sure $toc is an array

### DIFF
--- a/action.php
+++ b/action.php
@@ -219,7 +219,7 @@ class action_plugin_indexmenu extends DokuWiki_Action_Plugin {
         if(auth_quickaclcheck($id) < AUTH_READ) return '';
 
         $meta = p_get_metadata($id);
-        $toc  = $meta['description']['tableofcontents'];
+        $toc  = $meta['description']['tableofcontents'] ?? [];
 
         if(count($toc) > 1) {
             //display ToC of two or more headings


### PR DESCRIPTION
Encountered a warning while browsing my dokuwiki (preview site without toc):
`Warning: count(): Parameter must be an array or an object that implements Countable in /opt/dokuwiki/lib/plugins/indexmenu/action.php on line 224`
![warning](https://user-images.githubusercontent.com/30634945/168751850-6f49a116-d04e-469f-88ce-1f29d6ce34fa.png)
