### PR TITLE
Update syntax\indexmenu.php to use sexplode

### DIFF
--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -77,7 +77,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
 
         $match = substr($match, 12, -2);
         //split namespace,level,theme
-        list($nsstr, $optsstr) = explode('|', $match, 2);
+        list($nsstr, $optsstr) = sexplode('|', $match, 2);
         //split options
         $opts = explode(' ', $optsstr);
 

--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -77,7 +77,11 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
 
         $match = substr($match, 12, -2);
         //split namespace,level,theme
-        list($nsstr, $optsstr) = sexplode('|', $match, 2);
+        if (function_exists('sexplode')) {
+            list($nsstr, $optsstr) = sexplode('|', $match, 2);
+        } else {
+            list($nsstr, $optsstr) = array_pad(explode('|', $match, 2), 3, 0);
+        }
         //split options
         $opts = explode(' ', $optsstr);
 


### PR DESCRIPTION
Sexplode is a new function available on DokuWiki "Igor" (Dev Branch) that allows to split lists into a safe way. PHP 8.1 and Indexmenu was throwing an error on search page results on exploding without it when the user attempts to search when on Wiki home page (`wiki.example.com/doku.php?id=start`).