### PR TITLE
Fix deprecations: html_li_index and PageResolver

### DIFF
--- a/action.php
+++ b/action.php
@@ -352,7 +352,7 @@ class action_plugin_indexmenu extends DokuWiki_Action_Plugin {
         $out = '';
         if($_REQUEST['nojs']) {
             require_once(DOKU_INC.'inc/html.php');
-            $out_tmp = html_buildlist($data, 'idx', array($idxm, "_html_list_index"), "html_li_index");
+            $out_tmp = html_buildlist($data, 'idx', array($idxm, "_tagListItem"), "tagListItem");
             $out .= preg_replace('/<ul class="idx">(.*)<\/ul>/s', "$1", $out_tmp);
         } else {
             $nodes = $idxm->_jsnodes($data, '', 0);

--- a/action.php
+++ b/action.php
@@ -352,7 +352,7 @@ class action_plugin_indexmenu extends DokuWiki_Action_Plugin {
         $out = '';
         if($_REQUEST['nojs']) {
             require_once(DOKU_INC.'inc/html.php');
-            $out_tmp = html_buildlist($data, 'idx', array($idxm, "_tagListItem"), "tagListItem");
+            $out_tmp = html_buildlist($data, 'idx', array($idxm, "_html_list_index"), "tagListItem");
             $out .= preg_replace('/<ul class="idx">(.*)<\/ul>/s', "$1", $out_tmp);
         } else {
             $nodes = $idxm->_jsnodes($data, '', 0);

--- a/ajax.php
+++ b/ajax.php
@@ -189,7 +189,7 @@ class ajax_indexmenu_plugin {
         }
         if($_REQUEST['nojs']) {
             require_once(DOKU_INC.'inc/html.php');
-            $out_tmp = html_buildlist($data, 'idx', array($idxm, "_html_list_index"), "html_li_index");
+            $out_tmp = html_buildlist($data, 'idx', array($idxm, "_tagListItem"), "tagListItem");
             $out .= preg_replace('/<ul class="idx">(.*)<\/ul>/s', "$1", $out_tmp);
         } else {
             $nodes = $idxm->_jsnodes($data, '', 0);

--- a/ajax.php
+++ b/ajax.php
@@ -189,7 +189,7 @@ class ajax_indexmenu_plugin {
         }
         if($_REQUEST['nojs']) {
             require_once(DOKU_INC.'inc/html.php');
-            $out_tmp = html_buildlist($data, 'idx', array($idxm, "_tagListItem"), "tagListItem");
+            $out_tmp = html_buildlist($data, 'idx', array($idxm, "_html_list_index"), "tagListItem");
             $out .= preg_replace('/<ul class="idx">(.*)<\/ul>/s', "$1", $out_tmp);
         } else {
             $nodes = $idxm->_jsnodes($data, '', 0);

--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -428,7 +428,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
         //    the toggle interacts with hide needed for js option.
         $output = "\n";
         $output .= '<div><div id="nojs_'.$js_name.'" data-jsajax="'.utf8_encodeFN($js_opts['jsajax']).'" class="indexmenu_nojs">'."\n";
-        $output .= html_buildlist($data, 'idx', array($this, "_html_list_index"), "html_li_index");
+        $output .= html_buildlist($data, 'idx', array($this, "_tagListItem"), "tagListItem");
         $output .= "</div></div>\n";
         $output .= $output_tmp;
         return $output;

--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -6,7 +6,7 @@
  * @author      Samuele Tognini <samuele@samuele.netsons.org>
  *
  */
-
+use dokuwiki\File\PageResolver;
 if(!defined('DOKU_INC')) die();
 if(!defined('INDEXMENU_IMG_ABSDIR')) define('INDEXMENU_IMG_ABSDIR', DOKU_PLUGIN."indexmenu/images");
 
@@ -623,7 +623,9 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
         }
         //Just for old reelases compatibility
         if(empty($ns) || $ns == '..') $ns = ":..";
-        return resolve_id(getNS($id), $ns);
+            $resolver = new PageResolver($ns);
+            $id = $resolver->resolveId(getNS($id));
+            return $id;
     }
 
     /**

--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -617,15 +617,18 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
      * @return string id of namespace
      */
     public function _parse_ns($ns, $id = FALSE) {
-        if(!$id) {
+        if(!$id === false) {
             global $ID;
             $id = $ID;
         }
-        //Just for old reelases compatibility
-        if(empty($ns) || $ns == '..') $ns = ":..";
-            $resolver = new PageResolver($ns);
-            $id = $resolver->resolveId(getNS($id));
-            return $id;
+        //Just for old reelases compatibility, .. was an old version for : in the docs of indexmenu
+        if ($ns == '..') {
+            $ns = ":";
+        }
+        $ns = "$ns:arandompagehere";
+        $resolver = new PageResolver($id);
+        $ns = getNs($resolver->resolveId($ns));
+        return $ns === false ? '' : $ns;
     }
 
     /**

--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -428,7 +428,7 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
         //    the toggle interacts with hide needed for js option.
         $output = "\n";
         $output .= '<div><div id="nojs_'.$js_name.'" data-jsajax="'.utf8_encodeFN($js_opts['jsajax']).'" class="indexmenu_nojs">'."\n";
-        $output .= html_buildlist($data, 'idx', array($this, "_tagListItem"), "tagListItem");
+        $output .= html_buildlist($data, 'idx', array($this, "_html_list_index"), "tagListItem");
         $output .= "</div></div>\n";
         $output .= $output_tmp;
         return $output;


### PR DESCRIPTION
Nothing special to say: `html_li_index` is deprecated, `tagListItem` should be used instead. I am receiving a massive deprecation warning about this every day.

Also fixed PageResolver deprecation warning. 