### PR TITLE
Add data-wiki-id attr to Fancytree (Treenew)

### DIFF
--- a/script.js
+++ b/script.js
@@ -233,7 +233,7 @@ jQuery(function(){  // on page load
                     if(node.data.hnsNotExisting) {
                         cls = ' class="wikilink2"';
                     }
-                    data.$title.html("<a href='" + node.data.url + "'"+cls+">" + node.title + "</a>");
+                    data.$title.html("<a href='" + node.data.url + "'"+cls+" data-wiki-id='" + node.key + "'>" + node.title + "</a>");
                 }
             },
             //retrieve initial data


### PR DESCRIPTION
DokuWiki adds this attribute to "a" interwikis automatically, it points to the namespace/pageID, e.g. "doku.php?id=3cx:add_phones" the value of data-wiki-id attr is "3cx:add_phones". On Read the Dokus template, this attribute is used on sidebar to determine the "Next" and "Previous" buttons location.