### PR TITLE
Open links on a new tab when Ctrl (Win) / Command (macOS) key is pressed

### DIFF
--- a/script.js
+++ b/script.js
@@ -211,7 +211,13 @@ jQuery(function(){  // on page load
                 }
 
                 if(node.data.url){
-                    window.location.href = node.data.url;
+                    if (e.ctrlKey || e.metaKey) {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        window.open(node.data.url);
+                    } else {
+                        window.location.href = node.data.url;
+                    }
                 }
             },
 


### PR DESCRIPTION
When you're editing a page (&do=edit) and attempt to open another page through the sidebar pressing Ctrl (Windows) or Command (macOS) key, the plug-in attempts to load the clicked page on the current tab, triggering the alert "Changes not saved". This commit adds support for Ctrl (Win)/Command (macOS) key, so if those keys are pressed, instead of opening the link on the current tab, it opens the clicked link on a new tab.