### PR TITLE
Attempts to restore Hogfather compatibility

### DIFF
--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -769,10 +769,14 @@ class syntax_plugin_indexmenu_indexmenu extends SyntaxPlugin
         if ($ns == '..') {
             $ns = ":";
         }
-        $ns = "$ns:arandompagehere";
-        $resolver = new PageResolver($id);
-        $ns = getNs($resolver->resolveId($ns));
-        return $ns === false ? '' : $ns;
+        if (class_exists('dokuwiki\File\PageResolver')) {
+            $ns = "$ns:arandompagehere";
+            $resolver = new PageResolver($id);
+            $ns = getNs($resolver->resolveId($ns));
+            return $ns === false ? '' : $ns;
+        } else {
+            return resolve_id(getNS($id), $ns);
+        }
     }
 
     /**


### PR DESCRIPTION
The class PageResolver doesn't exists on DokuWiki Hogfather and older releases, so this PR attempts to fix https://github.com/samuelet/indexmenu/issues/291 by falling back to the old function "resolve_id" to parse NS if the class PageResolver isn't available.