### PR TITLE
Add sorting hook for dw2pdf plugin

### DIFF
--- a/_test/Dw2PdfTest.php
+++ b/_test/Dw2PdfTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace dokuwiki\plugin\indexmenu\test;
+
+use DokuWikiTest;
+
+/**
+ * dw2pdf tests for the indexmenu plugin
+ *
+ * @group plugin_indexmenu
+ * @group plugins
+ */
+class Dw2PdfTest extends DokuWikiTest
+{
+    /** @inheritdoc **/
+    protected $pluginsEnabled = ['indexmenu'];
+
+    /**
+     * Test sorting of pages in dw2pdf export
+     *
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function testSorting()
+    {
+        $pages = [
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:actions:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 2930,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:display_the_id_of_column_and_set:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 809,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:help_search:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 404,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:hot_keys:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 2717,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:external_links:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 986,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:start_page:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 978,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 958,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:integration-with-external-systems-by-injecting-javascript:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 1766,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:system_architecture:production_sizing_page',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 9805,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:system_architecture:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 14474,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:workstation:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 1381,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 4469,
+            ],
+        ];
+
+        $tags = [
+            'en:admin-guides:latest_release:getting_started:actions:start' => 10,
+            'en:admin-guides:latest_release:getting_started:display_the_id_of_column_and_set:start' => 9,
+            'en:admin-guides:latest_release:getting_started:help_search:start' => 3,
+            'en:admin-guides:latest_release:getting_started:hot_keys:start' => 9,
+            'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:external_links:start' => 2,
+            'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:start_page:start' => 1,
+            'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:start' => 2,
+            'en:admin-guides:latest_release:getting_started:integration-with-external-systems-by-injecting-javascript:start' => 210,
+            'en:admin-guides:latest_release:getting_started:system_architecture:production_sizing_page' => 1,
+            'en:admin-guides:latest_release:getting_started:system_architecture:start' => 6,
+            'en:admin-guides:latest_release:getting_started:workstation:start' => 1,
+            'en:admin-guides:latest_release:getting_started:start' => 1,
+        ];
+
+        $expected = [
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 4469,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:workstation:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 1381,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 958,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:start_page:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 978,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:how_to_navigate_in_datawalk_system:external_links:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 986,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:help_search:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 404,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:system_architecture:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 14474,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:system_architecture:production_sizing_page',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 9805,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:display_the_id_of_column_and_set:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 809,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:hot_keys:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 2717,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:actions:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 2930,
+            ],
+            [
+                'id' => 'en:admin-guides:latest_release:getting_started:integration-with-external-systems-by-injecting-javascript:start',
+                'rev' => 1769524502,
+                'mtime' => 1769524502,
+                'size' => 1766,
+            ],
+        ];
+
+        $action = plugin_load('action', 'indexmenu_dw2pdf');
+        self::setInaccessibleProperty($action, 'tags', $tags);
+
+
+        usort($pages, [$action, 'cbIndexmenuSort']);
+
+        $this->assertSame($expected, $pages);
+    }
+}

--- a/action/dw2pdf.php
+++ b/action/dw2pdf.php
@@ -1,0 +1,179 @@
+<?php
+
+use dokuwiki\Extension\ActionPlugin;
+use dokuwiki\Extension\Event;
+use dokuwiki\Extension\EventHandler;
+
+/**
+ * Class action_plugin_indexmenu_dw2pdf
+ */
+class action_plugin_indexmenu_dw2pdf extends ActionPlugin
+{
+    /**
+     * @var bool Strict mode requires a tag for all sorted pages
+     */
+    protected bool $isStrictMode;
+
+    /**
+     * @var array Page ids and their corresponding ordering tags
+     */
+    protected array $tags = [];
+
+    /**
+     * @param EventHandler $controller DokuWiki's event controller object.
+     */
+    public function register(EventHandler $controller)
+    {
+        $controller->register_hook('DW2PDF_NAMESPACEEXPORT_SORT', 'BEFORE', $this, 'sortPages2Pdf');
+    }
+
+    /**
+     * Triggered by dw2pdf plugin.
+     * Custom sorting of pages if "book_order" parameter was set to "indexmenu" or "indexmenu_strict"
+     *
+     * @param Event $event
+     * @return true
+     */
+    public function sortPages2Pdf(Event $event)
+    {
+        $sort = $event->data['sort'];
+        if ($sort === 'indexmenu' || $sort === 'indexmenu_strict') {
+            $this->isStrictMode = str_contains($sort, 'strict');
+            $event->preventDefault();
+
+            $pages =& $event->data['pages'];
+
+            // extract tags for easier testing
+            foreach ($pages as $page) {
+                $this->tags[$page['id']] = p_get_metadata($page['id'], 'indexmenu_n');
+                // break early in strict mode if tags are missing
+                if ($this->isStrictMode && is_null($this->tags[$page['id']])) {
+                    throw new Exception('Page ' . $page['id'] . ' does not exist or does not have an indexmenu tag!');
+                }
+            }
+
+            usort($pages, [$this, 'cbIndexmenuSort']);
+        }
+
+        return true;
+    }
+
+    /**
+     * usort callback to sort by indexmenu tag.
+     * Whole namespaces are sorted: start pages define the sort order on the same ns level.
+     *
+     * @param array $a Page info in event data
+     * @param array $b Page info in event data
+     * @return int
+     */
+    public function cbIndexmenuSort($a, $b)
+    {
+        global $conf;
+
+        $partsA = explode(':', $a['id']);
+        $partsB = explode(':', $b['id']);
+
+        //find where the namespaces diverge
+        [$nsA, $nsB] = $this->getFirstDifferentNs($partsA, $partsB);
+
+        // pages in the same namespace
+        if (is_null($nsA) && is_null($nsB)) {
+            // start page always has priority
+            if ($partsA[count($partsA) - 1] === $conf['start']) return -1;
+            if ($partsB[count($partsB) - 1] === $conf['start']) return 1;
+
+            // otherwise compare via indexmenu tag
+            return $this->tagCompare($a['id'], $b['id']);
+        }
+
+        // one of the pages is in a sub-namespace
+        if (is_null($nsA)) return -1;
+        if (is_null($nsB)) return 1;
+
+        // different namespaces, so first resolve the page holding the actual sorting order for this level
+        $idA = $this->resolveSortingAnchor($partsA, $nsA);
+        $idB = $this->resolveSortingAnchor($partsB, $nsB);
+
+        return $this->tagCompare($idA, $idB);
+    }
+
+    /**
+     * Compare ids based on indexmenu tag. If tags are missing or equal, do string comparison.
+     *
+     * @param string $idA
+     * @param string $idB
+     * @return int
+     */
+    public function tagCompare($idA, $idB)
+    {
+        $indexA = $this->tags[$idA];
+        $indexB = $this->tags[$idB];
+
+        if (is_null($indexA) || is_null($indexB) || $indexA === $indexB) {
+            return strnatcmp($idA, $idB);
+        }
+
+        return $indexA <=> $indexB;
+    }
+
+    /**
+     * Returns first different namespaces when comparing two arrays of namespace parts
+     *
+     * @param array $a Full id exploded by ":"
+     * @param array $b Full id exploded by ":"
+     * @return array
+     */
+    public function getFirstDifferentNs($a, $b)
+    {
+        $countA = count($a);
+        $countB = count($b);
+        $max = max($countA, $countB);
+
+        for ($i = 0; $i < $max - 1; $i++) {
+            $partA = $a[$i] ?: null;
+            $partB = $b[$i] ?: null;
+
+            if ($i === $countA - 1) {
+                return [null, $partB];
+            }
+
+            if ($i === $countB - 1) {
+                return [$partA, null];
+            }
+
+            if ($partA !== $partB) {
+                return [$partA, $partB];
+            }
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * Resolve the id of the page that is relevant for sorting (anchor).
+     * When comparing pages in different namespaces, it is necessary to reference the start page,
+     * because tags are used for sorting ACROSS and WITHIN namespaces.
+     *
+     * @param array $parts Full id exploded by ":"
+     * @param string $ns
+     * @return string
+     */
+    public function resolveSortingAnchor($parts, $ns)
+    {
+        global $conf;
+
+        $path_parts = [];
+        foreach ($parts as $part) {
+            $path_parts[] = $part;
+
+            // we hit the target namespace, append the start page and return immediately
+            if ($part === $ns) {
+                $path_parts[] = $conf["start"];
+                return implode(':', $path_parts);
+            }
+        }
+
+        // fallback
+        return implode(':', $parts);
+    }
+}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -26,6 +26,7 @@ $lang['checkupdates']          = 'Plugin updates';
 $lang['noupdates']             = 'Indexmenu does not need to be update. You have already the last release:';
 $lang['infos']                 = 'You can create your theme following the instructions at the <a href="https://www.dokuwiki.org/plugin:indexmenu#theme_tutorial">Theme Tutorial</a> page. <br />Then you could make more people happy :-) sending it to the public indexmenu repository, with the "share" button under that theme.';
 $lang['showsort']              = 'Indexmenu sort number: ';
+$lang['pdf_sort_err']          = 'Page %s does not have a required indexmenu tag';
 $lang['donation_text']         = 'The indexmenu plugin is not sponsored by anyone but i develop and support it for free during my spare time. If you gain something thanks to it or you want to support its development, you can consider to make a donation.';
 $lang['js']['indexmenuwizard'] = 'Indexmenu Wizard';
 $lang['js']['index']           = 'Index';


### PR DESCRIPTION
Recent refactoring of dw2pdf has introduced a new event `DW2PDF_NAMESPACEEXPORT_SORT`.

This PR adds a simple sort function which sorts pages based on their indexmenu tag (`indexmenu_n`).

This sorting will only take place if dw2pdf receives parameter `book_order=indexmenu` or `book_order=indexmenu_strict`. In the strict mode, tags are required for PDF export and an exception will be thrown if one of the pages is missing a tag.