### PR TITLE
Fix condition to check for empty directory removal

### DIFF
--- a/Search.php
+++ b/Search.php
@@ -698,7 +698,7 @@ class Search
         if ($added === 0 && $files_tmp === []) {
             //remove empty directory again, only if it has not a headpage associated
             $lastItem = end($data);
-            if (isset($lastItem['hns']) && !$lastItem['hns']) {
+            if (empty($lastItem['hns'])) {
                 array_pop($data);
             }
         } elseif (!($this->nsort && !$this->group)) {

--- a/Search.php
+++ b/Search.php
@@ -698,7 +698,7 @@ class Search
         if ($added === 0 && $files_tmp === []) {
             //remove empty directory again, only if it has not a headpage associated
             $lastItem = end($data);
-            if (empty($lastItem['hns'])) {
+            if (blank($lastItem['hns'])) {
                 array_pop($data);
             }
         } elseif (!($this->nsort && !$this->group)) {

--- a/Search.php
+++ b/Search.php
@@ -698,7 +698,7 @@ class Search
         if ($added === 0 && $files_tmp === []) {
             //remove empty directory again, only if it has not a headpage associated
             $lastItem = end($data);
-            if (!$lastItem['hns']) {
+            if (isset($lastItem['hns']) && !$lastItem['hns']) {
                 array_pop($data);
             }
         } elseif (!($this->nsort && !$this->group)) {


### PR DESCRIPTION
The following error is thrown when running Aichat cron:

```
2026-01-21 15:17:38
E_WARNING: Trying to access array offset on false
/var/www/dokuwiki/lib/plugins/indexmenu/Search.php(704)
#0 /var/www/dokuwiki/lib/plugins/indexmenu/Search.php(704): dokuwiki\ErrorHandler::errorHandler()
#1 /var/www/dokuwiki/lib/plugins/indexmenu/Search.php(243): dokuwiki\plugin\indexmenu\Search->customSearch()
#2 /var/www/dokuwiki/lib/plugins/indexmenu/syntax/indexmenu.php(510): dokuwiki\plugin\indexmenu\Search->search()
#3 /var/www/dokuwiki/lib/plugins/indexmenu/syntax/indexmenu.php(466): syntax_plugin_indexmenu_indexmenu->buildHtmlIndexmenu()
#4 /var/www/dokuwiki/lib/plugins/aichat/renderer.php(63): syntax_plugin_indexmenu_indexmenu->render()
#5 /var/www/dokuwiki/inc/parserutils.php(691): renderer_plugin_aichat->plugin()
#6 /var/www/dokuwiki/inc/parserutils.php(158): p_render()
#7 /var/www/dokuwiki/lib/plugins/aichat/Embeddings.php(206): p_cached_output()
#8 /var/www/dokuwiki/lib/plugins/aichat/Embeddings.php(233): dokuwiki\plugin\aichat\Embeddings->getPageContent()
#9 /var/www/dokuwiki/lib/plugins/aichat/Embeddings.php(185): dokuwiki\plugin\aichat\Embeddings->createPageChunks()
#10 /var/www/dokuwiki/lib/plugins/aichat/cli.php(374): dokuwiki\plugin\aichat\Embeddings->createNewIndex()
#11 /var/www/dokuwiki/lib/plugins/aichat/cli.php(94): cli_plugin_aichat->createEmbeddings()
#12 /var/www/dokuwiki/vendor/splitbrain/php-cli/src/Base.php(217): cli_plugin_aichat->main()
#13 /var/www/dokuwiki/vendor/splitbrain/php-cli/src/Base.php(145): splitbrain\phpcli\Base->execute()
#14 /var/www/dokuwiki/bin/plugin.php(45): splitbrain\phpcli\Base->run()
#15 /var/www/dokuwiki/vendor/splitbrain/php-cli/src/Base.php(217): PluginCLI->main()
#16 /var/www/dokuwiki/vendor/splitbrain/php-cli/src/Base.php(145): splitbrain\phpcli\Base->execute()
#17 /var/www/dokuwiki/bin/plugin.php(111): splitbrain\phpcli\Base->run()
#18 {main}
```