### PR TITLE
harden: remove unsafe eval() in pclzip.lib.php...

### DIFF
--- a/inc/pclzip.lib.php
+++ b/inc/pclzip.lib.php
@@ -2447,9 +2447,7 @@ class PclZip
             $this->privConvertHeader2FileInfo($p_header, $v_local_header);
 
           // ----- Call the callback
-          // Here I do not use call_user_func() because I need to send a reference to the
-          // header.
-            eval('$v_result = ' . $p_options[PCLZIP_CB_PRE_ADD] . '(PCLZIP_CB_PRE_ADD, $v_local_header);');
+            $v_result = call_user_func_array($p_options[PCLZIP_CB_PRE_ADD], [PCLZIP_CB_PRE_ADD, &$v_local_header]);
             if ($v_result == 0) {
               // ----- Change the file status
                 $p_header['status'] = "skipped";
@@ -2584,9 +2582,7 @@ class PclZip
             $this->privConvertHeader2FileInfo($p_header, $v_local_header);
 
           // ----- Call the callback
-          // Here I do not use call_user_func() because I need to send a reference to the
-          // header.
-            eval('$v_result = ' . $p_options[PCLZIP_CB_POST_ADD] . '(PCLZIP_CB_POST_ADD, $v_local_header);');
+            $v_result = call_user_func_array($p_options[PCLZIP_CB_POST_ADD], [PCLZIP_CB_POST_ADD, &$v_local_header]);
             if ($v_result == 0) {
               // ----- Ignored
                 $v_result = 1;
@@ -3482,9 +3478,7 @@ class PclZip
             $this->privConvertHeader2FileInfo($p_entry, $v_local_header);
 
           // ----- Call the callback
-          // Here I do not use call_user_func() because I need to send a reference to the
-          // header.
-            eval('$v_result = ' . $p_options[PCLZIP_CB_PRE_EXTRACT] . '(PCLZIP_CB_PRE_EXTRACT, $v_local_header);');
+            $v_result = call_user_func_array($p_options[PCLZIP_CB_PRE_EXTRACT], [PCLZIP_CB_PRE_EXTRACT, &$v_local_header]);
             if ($v_result == 0) {
               // ----- Change the file status
                 $p_entry['status'] = "skipped";
@@ -3745,9 +3739,7 @@ class PclZip
             $this->privConvertHeader2FileInfo($p_entry, $v_local_header);
 
           // ----- Call the callback
-          // Here I do not use call_user_func() because I need to send a reference to the
-          // header.
-            eval('$v_result = ' . $p_options[PCLZIP_CB_POST_EXTRACT] . '(PCLZIP_CB_POST_EXTRACT, $v_local_header);');
+            $v_result = call_user_func_array($p_options[PCLZIP_CB_POST_EXTRACT], [PCLZIP_CB_POST_EXTRACT, &$v_local_header]);
 
           // ----- Look for abort result
             if ($v_result == 2) {
@@ -3795,9 +3787,7 @@ class PclZip
             $this->privConvertHeader2FileInfo($p_entry, $v_local_header);
 
           // ----- Call the callback
-          // Here I do not use call_user_func() because I need to send a reference to the
-          // header.
-            eval('$v_result = ' . $p_options[PCLZIP_CB_PRE_EXTRACT] . '(PCLZIP_CB_PRE_EXTRACT, $v_local_header);');
+            $v_result = call_user_func_array($p_options[PCLZIP_CB_PRE_EXTRACT], [PCLZIP_CB_PRE_EXTRACT, &$v_local_header]);
             if ($v_result == 0) {
               // ----- Change the file status
                 $p_entry['status'] = "skipped";
@@ -3869,9 +3859,7 @@ class PclZip
             $this->privConvertHeader2FileInfo($p_entry, $v_local_header);
 
           // ----- Call the callback
-          // Here I do not use call_user_func() because I need to send a reference to the
-          // header.
-            eval('$v_result = ' . $p_options[PCLZIP_CB_POST_EXTRACT] . '(PCLZIP_CB_POST_EXTRACT, $v_local_header);');
+            $v_result = call_user_func_array($p_options[PCLZIP_CB_POST_EXTRACT], [PCLZIP_CB_POST_EXTRACT, &$v_local_header]);
 
           // ----- Look for abort result
             if ($v_result == 2) {


### PR DESCRIPTION
## Summary
Harden input handling in `inc/pclzip.lib.php` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | php.lang.security.eval-use.eval-use |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `php.lang.security.eval-use.eval-use` |
| **File** | `inc/pclzip.lib.php:2452` |
| **Assessment** | Defensive hardening |

**Description**: Evaluating non-constant commands. This can lead to command injection.

## Changes
- `inc/pclzip.lib.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
